### PR TITLE
Add filter to exclude system event messages

### DIFF
--- a/channels/ops.go
+++ b/channels/ops.go
@@ -96,12 +96,12 @@ func (o *ops) SendReply(ctx context.Context, teamID, channelID, messageID string
 	return adapter.MapGraphMessage(resp), nil
 }
 
-func (o *ops) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (o *ops) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	var top *int32
 	if opts != nil && opts.Top != nil {
 		top = opts.Top
 	}
-	resp, requestErr := o.channelAPI.ListMessages(ctx, teamID, channelID, top)
+	resp, requestErr := o.channelAPI.ListMessages(ctx, teamID, channelID, top, includeSystem)
 	if requestErr != nil {
 		return nil, snd.MapError(requestErr, snd.WithResource(resources.Team, teamID), snd.WithResource(resources.Channel, channelID))
 	}
@@ -121,12 +121,12 @@ func (o *ops) GetMessage(ctx context.Context, teamID, channelID, messageID strin
 	return adapter.MapGraphMessage(resp), nil
 }
 
-func (o *ops) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (o *ops) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	var top *int32
 	if opts != nil && opts.Top != nil {
 		top = opts.Top
 	}
-	resp, requestErr := o.channelAPI.ListReplies(ctx, teamID, channelID, messageID, top)
+	resp, requestErr := o.channelAPI.ListReplies(ctx, teamID, channelID, messageID, top, includeSystem)
 	if requestErr != nil {
 		return nil, snd.MapError(
 			requestErr,

--- a/channels/ops_interface.go
+++ b/channels/ops_interface.go
@@ -14,9 +14,9 @@ type channelOps interface {
 	DeleteChannel(ctx context.Context, teamID, channelID, channelRef string) error
 	SendMessage(ctx context.Context, teamID, channelID string, body models.MessageBody) (*models.Message, error)
 	SendReply(ctx context.Context, teamID, channelID, messageID string, body models.MessageBody) (*models.Message, error)
-	ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions) ([]*models.Message, error)
+	ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error)
 	GetMessage(ctx context.Context, teamID, channelID, messageID string) (*models.Message, error)
-	ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions) ([]*models.Message, error)
+	ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error)
 	GetReply(ctx context.Context, teamID, channelID, messageID, replyID string) (*models.Message, error)
 	ListMembers(ctx context.Context, teamID, channelID string) ([]*models.Member, error)
 	AddMember(ctx context.Context, teamID, channelID, userID string, isOwner bool) (*models.Member, error)

--- a/channels/ops_test.go
+++ b/channels/ops_test.go
@@ -443,12 +443,12 @@ func TestOps_ListMessages(t *testing.T) {
 				testutil.NewGraphMessage(&testutil.NewMessageParams{ID: util.Ptr("m2"), Content: util.Ptr("b")}),
 			})
 			d.channelAPI.EXPECT().
-				ListMessages(gomock.Any(), "team-1", "chan-1", nil).
+				ListMessages(gomock.Any(), "team-1", "chan-1", nil, false).
 				Return(col, nil).
 				Times(1)
 		})
 
-		got, err := op.ListMessages(ctx, "team-1", "chan-1", nil)
+		got, err := op.ListMessages(ctx, "team-1", "chan-1", nil, false)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
 		assert.Equal(t, "m1", got[0].ID)
@@ -461,12 +461,12 @@ func TestOps_ListMessages(t *testing.T) {
 			col := msmodels.NewChatMessageCollectionResponse()
 			col.SetValue([]msmodels.ChatMessageable{})
 			d.channelAPI.EXPECT().
-				ListMessages(gomock.Any(), "team-1", "chan-1", &top).
+				ListMessages(gomock.Any(), "team-1", "chan-1", &top, false).
 				Return(col, nil).
 				Times(1)
 		})
 
-		_, err := op.ListMessages(ctx, "team-1", "chan-1", &models.ListMessagesOptions{Top: &top})
+		_, err := op.ListMessages(ctx, "team-1", "chan-1", &models.ListMessagesOptions{Top: &top}, false)
 		require.NoError(t, err)
 	})
 
@@ -474,12 +474,12 @@ func TestOps_ListMessages(t *testing.T) {
 		var top int32 = 5
 		op, ctx := newOpsSUT(t, func(d opsSUTDeps) {
 			d.channelAPI.EXPECT().
-				ListMessages(gomock.Any(), "team-1", "chan-1", &top).
+				ListMessages(gomock.Any(), "team-1", "chan-1", &top, false).
 				Return(nil, &snd.RequestError{Code: 404, Message: "missing"}).
 				Times(1)
 		})
 
-		got, err := op.ListMessages(ctx, "team-1", "chan-1", &models.ListMessagesOptions{Top: &top})
+		got, err := op.ListMessages(ctx, "team-1", "chan-1", &models.ListMessagesOptions{Top: &top}, false)
 		require.Nil(t, got)
 		require.Error(t, err)
 
@@ -541,12 +541,12 @@ func TestOps_ListReplies(t *testing.T) {
 				testutil.NewGraphMessage(&testutil.NewMessageParams{ID: util.Ptr("r1"), Content: util.Ptr("x")}),
 			})
 			d.channelAPI.EXPECT().
-				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", nil).
+				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", nil, false).
 				Return(col, nil).
 				Times(1)
 		})
 
-		got, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", nil)
+		got, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", nil, false)
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 		assert.Equal(t, "r1", got[0].ID)
@@ -558,12 +558,12 @@ func TestOps_ListReplies(t *testing.T) {
 			col := msmodels.NewChatMessageCollectionResponse()
 			col.SetValue([]msmodels.ChatMessageable{})
 			d.channelAPI.EXPECT().
-				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", &top).
+				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", &top, false).
 				Return(col, nil).
 				Times(1)
 		})
 
-		_, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", &models.ListMessagesOptions{Top: &top})
+		_, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", &models.ListMessagesOptions{Top: &top}, false)
 		require.NoError(t, err)
 	})
 
@@ -571,12 +571,12 @@ func TestOps_ListReplies(t *testing.T) {
 		var top int32 = 5
 		op, ctx := newOpsSUT(t, func(d opsSUTDeps) {
 			d.channelAPI.EXPECT().
-				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", &top).
+				ListReplies(gomock.Any(), "team-1", "chan-1", "m-1", &top, false).
 				Return(nil, &snd.RequestError{Code: 404, Message: "missing"}).
 				Times(1)
 		})
 
-		got, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", &models.ListMessagesOptions{Top: &top})
+		got, err := op.ListReplies(ctx, "team-1", "chan-1", "m-1", &models.ListMessagesOptions{Top: &top}, false)
 		require.Nil(t, got)
 		require.Error(t, err)
 

--- a/channels/ops_with_cache.go
+++ b/channels/ops_with_cache.go
@@ -109,15 +109,15 @@ func (o *opsWithCache) SendReply(ctx context.Context, teamID, channelID, message
 	}, o.cacheHandler)
 }
 
-func (o *opsWithCache) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (o *opsWithCache) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	return cacher.WithErrorClear(func() ([]*models.Message, error) {
-		return o.chanOps.ListMessages(ctx, teamID, channelID, opts)
+		return o.chanOps.ListMessages(ctx, teamID, channelID, opts, includeSystem)
 	}, o.cacheHandler)
 }
 
-func (o *opsWithCache) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (o *opsWithCache) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	return cacher.WithErrorClear(func() ([]*models.Message, error) {
-		return o.chanOps.ListReplies(ctx, teamID, channelID, messageID, opts)
+		return o.chanOps.ListReplies(ctx, teamID, channelID, messageID, opts, includeSystem)
 	}, o.cacheHandler)
 }
 

--- a/channels/ops_with_cache_test.go
+++ b/channels/ops_with_cache_test.go
@@ -435,20 +435,20 @@ func TestOpsWithCache_WithErrorClearMethods_ClearCacheOnError(t *testing.T) {
 		{
 			name: "ListMessages",
 			expect: func(d opsWithCacheSUTDeps) {
-				d.chanOps.EXPECT().ListMessages(gomock.Any(), teamID, channelID, gomock.Any()).Return(nil, err400).Times(1)
+				d.chanOps.EXPECT().ListMessages(gomock.Any(), teamID, channelID, gomock.Any(), false).Return(nil, err400).Times(1)
 			},
 			call: func(sut channelOps, ctx context.Context) (bool, error) {
-				msgs, err := sut.ListMessages(ctx, teamID, channelID, nil)
+				msgs, err := sut.ListMessages(ctx, teamID, channelID, nil, false)
 				return msgs == nil, err
 			},
 		},
 		{
 			name: "ListReplies",
 			expect: func(d opsWithCacheSUTDeps) {
-				d.chanOps.EXPECT().ListReplies(gomock.Any(), teamID, channelID, messageID, gomock.Any()).Return(nil, err400).Times(1)
+				d.chanOps.EXPECT().ListReplies(gomock.Any(), teamID, channelID, messageID, gomock.Any(), false).Return(nil, err400).Times(1)
 			},
 			call: func(sut channelOps, ctx context.Context) (bool, error) {
-				msgs, err := sut.ListReplies(ctx, teamID, channelID, messageID, nil)
+				msgs, err := sut.ListReplies(ctx, teamID, channelID, messageID, nil, false)
 				return msgs == nil, err
 			},
 		},

--- a/channels/service.go
+++ b/channels/service.go
@@ -145,7 +145,7 @@ func (s *service) SendReply(ctx context.Context, teamRef, channelRef, messageID 
 	return out, nil
 }
 
-func (s *service) ListMessages(ctx context.Context, teamRef, channelRef string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (s *service) ListMessages(ctx context.Context, teamRef, channelRef string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	teamID, channelID, err := s.resolveTeamAndChannelID(ctx, teamRef, channelRef)
 	if err != nil {
 		return nil, sender.Wrap("ListMessages", err,
@@ -153,7 +153,7 @@ func (s *service) ListMessages(ctx context.Context, teamRef, channelRef string, 
 			sender.NewParam(resources.ChannelRef, channelRef),
 		)
 	}
-	out, err := s.ops.ListMessages(ctx, teamID, channelID, opts)
+	out, err := s.ops.ListMessages(ctx, teamID, channelID, opts, includeSystem)
 	if err != nil {
 		return nil, sender.Wrap("ListMessages", err,
 			sender.NewParam(resources.TeamRef, teamRef),
@@ -183,7 +183,7 @@ func (s *service) GetMessage(ctx context.Context, teamRef, channelRef, messageID
 	return out, nil
 }
 
-func (s *service) ListReplies(ctx context.Context, teamRef, channelRef, messageID string, top *int32) ([]*models.Message, error) {
+func (s *service) ListReplies(ctx context.Context, teamRef, channelRef, messageID string, top *int32, includeSystem bool) ([]*models.Message, error) {
 	teamID, channelID, err := s.resolveTeamAndChannelID(ctx, teamRef, channelRef)
 	if err != nil {
 		return nil, sender.Wrap("ListReplies", err,
@@ -192,7 +192,7 @@ func (s *service) ListReplies(ctx context.Context, teamRef, channelRef, messageI
 		)
 	}
 
-	out, err := s.ops.ListReplies(ctx, teamID, channelID, messageID, &models.ListMessagesOptions{Top: top})
+	out, err := s.ops.ListReplies(ctx, teamID, channelID, messageID, &models.ListMessagesOptions{Top: top}, includeSystem)
 	if err != nil {
 		return nil, sender.Wrap("ListReplies", err,
 			sender.NewParam(resources.TeamRef, teamRef),

--- a/channels/service_interface.go
+++ b/channels/service_interface.go
@@ -55,13 +55,13 @@ type Service interface {
 	SendReply(ctx context.Context, teamRef, channelRef, messageID string, body models.MessageBody) (*models.Message, error)
 
 	// ListMessages returns all messages in a channel.
-	ListMessages(ctx context.Context, teamRef, channelRef string, opts *models.ListMessagesOptions) ([]*models.Message, error)
+	ListMessages(ctx context.Context, teamRef, channelRef string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error)
 
 	// GetMessage retrieves a specific message from a channel by its ID.
 	GetMessage(ctx context.Context, teamRef, channelRef, messageID string) (*models.Message, error)
 
 	// ListReplies returns all replies to a specific message in a channel.
-	ListReplies(ctx context.Context, teamRef, channelRef, messageID string, top *int32) ([]*models.Message, error)
+	ListReplies(ctx context.Context, teamRef, channelRef, messageID string, top *int32, includeSystem bool) ([]*models.Message, error)
 
 	// GetReply retrieves a specific reply to a message in a channel by its ID.
 	GetReply(ctx context.Context, teamRef, channelRef, messageID, replyID string) (*models.Message, error)

--- a/chats/ops.go
+++ b/chats/ops.go
@@ -72,8 +72,8 @@ func (o *ops) UpdateGroupChatTopic(ctx context.Context, chatID, topic string) (*
 	return adapter.MapGraphChat(resp), nil
 }
 
-func (o *ops) ListMessages(ctx context.Context, chatID string) ([]*models.Message, error) {
-	resp, requestErr := o.chatAPI.ListMessages(ctx, chatID)
+func (o *ops) ListMessages(ctx context.Context, chatID string, includeSystem bool) ([]*models.Message, error) {
+	resp, requestErr := o.chatAPI.ListMessages(ctx, chatID, includeSystem)
 	if requestErr != nil {
 		return nil, snd.MapError(requestErr, snd.WithResource(resources.Chat, chatID))
 	}

--- a/chats/ops_interface.go
+++ b/chats/ops_interface.go
@@ -14,7 +14,7 @@ type chatOps interface {
 	RemoveMemberFromGroupChat(ctx context.Context, chatID, userID string) error
 	ListGroupChatMembers(ctx context.Context, chatID string) ([]*models.Member, error)
 	UpdateGroupChatTopic(ctx context.Context, chatID, topic string) (*models.Chat, error)
-	ListMessages(ctx context.Context, chatID string) ([]*models.Message, error)
+	ListMessages(ctx context.Context, chatID string, includeSystem bool) ([]*models.Message, error)
 	SendMessage(ctx context.Context, chatID string, body models.MessageBody) (*models.Message, error)
 	DeleteMessage(ctx context.Context, chatID, messageID string) error
 	GetMessage(ctx context.Context, chatID, messageID string) (*models.Message, error)

--- a/chats/ops_with_cache.go
+++ b/chats/ops_with_cache.go
@@ -106,9 +106,9 @@ func (o *opsWithCache) UpdateGroupChatTopic(ctx context.Context, chatID, topic s
 	}, o.cacheHandler)
 }
 
-func (o *opsWithCache) ListMessages(ctx context.Context, chatID string) ([]*models.Message, error) {
+func (o *opsWithCache) ListMessages(ctx context.Context, chatID string, includeSystem bool) ([]*models.Message, error) {
 	return cacher.WithErrorClear(func() ([]*models.Message, error) {
-		return o.chatOps.ListMessages(ctx, chatID)
+		return o.chatOps.ListMessages(ctx, chatID, includeSystem)
 	}, o.cacheHandler)
 }
 

--- a/chats/service.go
+++ b/chats/service.go
@@ -127,7 +127,7 @@ func (s *service) UpdateGroupChatTopic(ctx context.Context, chatRef GroupChatRef
 	return resp, nil
 }
 
-func (s *service) ListMessages(ctx context.Context, chatRef ChatRef) ([]*models.Message, error) {
+func (s *service) ListMessages(ctx context.Context, chatRef ChatRef, includeSystem bool) ([]*models.Message, error) {
 	chatID, err := s.resolveChatIDFromRef(ctx, chatRef)
 	if err != nil {
 		return nil, snd.Wrap("ListMessages", err,
@@ -135,7 +135,7 @@ func (s *service) ListMessages(ctx context.Context, chatRef ChatRef) ([]*models.
 		)
 	}
 
-	resp, err := s.chatOps.ListMessages(ctx, chatID)
+	resp, err := s.chatOps.ListMessages(ctx, chatID, includeSystem)
 	if err != nil {
 		return nil, snd.Wrap("ListMessages", err,
 			snd.NewParam(resources.ChatRef, chatRef.get()),

--- a/chats/service_interface.go
+++ b/chats/service_interface.go
@@ -43,7 +43,7 @@ type Service interface {
 	UpdateGroupChatTopic(ctx context.Context, chatRef GroupChatRef, topic string) (*models.Chat, error)
 
 	// ListMessages returns all messages in a chat.
-	ListMessages(ctx context.Context, chatRef ChatRef) ([]*models.Message, error)
+	ListMessages(ctx context.Context, chatRef ChatRef, includeSystem bool) ([]*models.Message, error)
 
 	// SendMessage sends a message to a chat.
 	// Body parameter is the body of the message. It includes:
@@ -62,6 +62,8 @@ type Service interface {
 	ListChats(ctx context.Context, chatType *models.ChatType) ([]*models.Chat, error)
 
 	// ListAllMessages returns all messages in all chats within the specified time range. Top limits the number of messages returned.
+	//
+	// Note: This operation does not work in delegated permission mode.
 	ListAllMessages(ctx context.Context, startTime, endTime *time.Time, top *int32) ([]*models.Message, error)
 
 	// ListPinnedMessages returns all pinned messages in a chat.

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -56,3 +56,28 @@ func newTypeError(expected string) *sender.RequestError {
 		Message: "Expected " + expected,
 	}
 }
+
+func isSystemEvent(m msmodels.ChatMessageable) bool {
+	if m.GetEventDetail() != nil {
+		return true
+	}
+	if mt := m.GetMessageType(); mt != nil && *mt == msmodels.CHATEVENT_CHATMESSAGETYPE {
+		return true
+	}
+	return false
+}
+
+func filterOutSystemEvents(messages msmodels.ChatMessageCollectionResponseable) []msmodels.ChatMessageable {
+	vals := messages.GetValue()
+	if vals == nil {
+		return nil
+	}
+	filtered := make([]msmodels.ChatMessageable, 0, len(vals))
+	for _, v := range vals {
+		if v == nil || isSystemEvent(v) {
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+	return filtered
+}

--- a/internal/testutil/mock_channel_api.go
+++ b/internal/testutil/mock_channel_api.go
@@ -177,33 +177,33 @@ func (mr *MockChannelAPIMockRecorder) ListMembers(ctx, teamID, channelID any) *g
 }
 
 // ListMessages mocks base method.
-func (m *MockChannelAPI) ListMessages(ctx context.Context, teamID, channelID string, top *int32) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
+func (m *MockChannelAPI) ListMessages(ctx context.Context, teamID, channelID string, top *int32, includeSystem bool) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMessages", ctx, teamID, channelID, top)
+	ret := m.ctrl.Call(m, "ListMessages", ctx, teamID, channelID, top, includeSystem)
 	ret0, _ := ret[0].(models.ChatMessageCollectionResponseable)
 	ret1, _ := ret[1].(*sender.RequestError)
 	return ret0, ret1
 }
 
 // ListMessages indicates an expected call of ListMessages.
-func (mr *MockChannelAPIMockRecorder) ListMessages(ctx, teamID, channelID, top any) *gomock.Call {
+func (mr *MockChannelAPIMockRecorder) ListMessages(ctx, teamID, channelID, top, includeSystem any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockChannelAPI)(nil).ListMessages), ctx, teamID, channelID, top)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockChannelAPI)(nil).ListMessages), ctx, teamID, channelID, top, includeSystem)
 }
 
 // ListReplies mocks base method.
-func (m *MockChannelAPI) ListReplies(ctx context.Context, teamID, channelID, messageID string, top *int32) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
+func (m *MockChannelAPI) ListReplies(ctx context.Context, teamID, channelID, messageID string, top *int32, includeSystem bool) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListReplies", ctx, teamID, channelID, messageID, top)
+	ret := m.ctrl.Call(m, "ListReplies", ctx, teamID, channelID, messageID, top, includeSystem)
 	ret0, _ := ret[0].(models.ChatMessageCollectionResponseable)
 	ret1, _ := ret[1].(*sender.RequestError)
 	return ret0, ret1
 }
 
 // ListReplies indicates an expected call of ListReplies.
-func (mr *MockChannelAPIMockRecorder) ListReplies(ctx, teamID, channelID, messageID, top any) *gomock.Call {
+func (mr *MockChannelAPIMockRecorder) ListReplies(ctx, teamID, channelID, messageID, top, includeSystem any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReplies", reflect.TypeOf((*MockChannelAPI)(nil).ListReplies), ctx, teamID, channelID, messageID, top)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReplies", reflect.TypeOf((*MockChannelAPI)(nil).ListReplies), ctx, teamID, channelID, messageID, top, includeSystem)
 }
 
 // RemoveMember mocks base method.

--- a/internal/testutil/mock_channel_ops.go
+++ b/internal/testutil/mock_channel_ops.go
@@ -191,33 +191,33 @@ func (mr *MockchannelOpsMockRecorder) ListMembers(ctx, teamID, channelID any) *g
 }
 
 // ListMessages mocks base method.
-func (m *MockchannelOps) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (m *MockchannelOps) ListMessages(ctx context.Context, teamID, channelID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMessages", ctx, teamID, channelID, opts)
+	ret := m.ctrl.Call(m, "ListMessages", ctx, teamID, channelID, opts, includeSystem)
 	ret0, _ := ret[0].([]*models.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListMessages indicates an expected call of ListMessages.
-func (mr *MockchannelOpsMockRecorder) ListMessages(ctx, teamID, channelID, opts any) *gomock.Call {
+func (mr *MockchannelOpsMockRecorder) ListMessages(ctx, teamID, channelID, opts, includeSystem any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockchannelOps)(nil).ListMessages), ctx, teamID, channelID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockchannelOps)(nil).ListMessages), ctx, teamID, channelID, opts, includeSystem)
 }
 
 // ListReplies mocks base method.
-func (m *MockchannelOps) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions) ([]*models.Message, error) {
+func (m *MockchannelOps) ListReplies(ctx context.Context, teamID, channelID, messageID string, opts *models.ListMessagesOptions, includeSystem bool) ([]*models.Message, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListReplies", ctx, teamID, channelID, messageID, opts)
+	ret := m.ctrl.Call(m, "ListReplies", ctx, teamID, channelID, messageID, opts, includeSystem)
 	ret0, _ := ret[0].([]*models.Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListReplies indicates an expected call of ListReplies.
-func (mr *MockchannelOpsMockRecorder) ListReplies(ctx, teamID, channelID, messageID, opts any) *gomock.Call {
+func (mr *MockchannelOpsMockRecorder) ListReplies(ctx, teamID, channelID, messageID, opts, includeSystem any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReplies", reflect.TypeOf((*MockchannelOps)(nil).ListReplies), ctx, teamID, channelID, messageID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReplies", reflect.TypeOf((*MockchannelOps)(nil).ListReplies), ctx, teamID, channelID, messageID, opts, includeSystem)
 }
 
 // RemoveMember mocks base method.

--- a/internal/testutil/mock_chat_api.go
+++ b/internal/testutil/mock_chat_api.go
@@ -300,18 +300,18 @@ func (mr *MockChatAPIMockRecorder) ListGroupChatMembers(ctx, chatID any) *gomock
 }
 
 // ListMessages mocks base method.
-func (m *MockChatAPI) ListMessages(ctx context.Context, chatID string) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
+func (m *MockChatAPI) ListMessages(ctx context.Context, chatID string, includeSystem bool) (models.ChatMessageCollectionResponseable, *sender.RequestError) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMessages", ctx, chatID)
+	ret := m.ctrl.Call(m, "ListMessages", ctx, chatID, includeSystem)
 	ret0, _ := ret[0].(models.ChatMessageCollectionResponseable)
 	ret1, _ := ret[1].(*sender.RequestError)
 	return ret0, ret1
 }
 
 // ListMessages indicates an expected call of ListMessages.
-func (mr *MockChatAPIMockRecorder) ListMessages(ctx, chatID any) *gomock.Call {
+func (mr *MockChatAPIMockRecorder) ListMessages(ctx, chatID, includeSystem any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockChatAPI)(nil).ListMessages), ctx, chatID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMessages", reflect.TypeOf((*MockChatAPI)(nil).ListMessages), ctx, chatID, includeSystem)
 }
 
 // ListPinnedMessages mocks base method.


### PR DESCRIPTION
## Summary
This PR adds an `includeSystem` boolean flag to ListMessages/ListReplies to optionally include Teams system event messages (`messageType = systemEventMessage`). Because the channel messages listing endpoint doesn’t support `$filter` (only `$top`/`$expand`), the filtering is applied client-side after receiving the API response.
